### PR TITLE
Support for multiple notifications

### DIFF
--- a/argusclient/client.py
+++ b/argusclient/client.py
@@ -391,7 +391,18 @@ class AlertsServiceClient(BaseUpdatableModelServiceClient):
             alertobj.trigger = alertobj.triggers.add(alert.trigger)
         if alert.notification:
             alertobj.notification = alertobj.notifications.add(alert.notification)
-        if alert.trigger and alert.notification:
+        elif alert.notifications and isinstance(alert.notifications, list):
+            notifications = []
+            for notification in alert.notifications:
+                notifications.append(alertobj.notifications.add(notification))
+            alertobj.notifications = notifications
+        if alert.trigger and alert.notifications:
+            alertobj.trigger.notificationsIds = []
+            for notification in alertobj.notifications:
+                self.argus.alerts.add_notification_trigger(alertobj.id, notification.id, alertobj.trigger.id)
+                notification.triggersIds = [alertobj.trigger.id]
+                alertobj.trigger.notificationsIds.append(notification.id)
+        elif alert.trigger and alert.notification:
             self.argus.alerts.add_notification_trigger(alertobj.id, alertobj.notification.id, alertobj.trigger.id)
             alertobj.notification.triggersIds = [alertobj.trigger.id]
             alertobj.trigger.notificationsIds = [alertobj.notification.id]

--- a/argusclient/model.py
+++ b/argusclient/model.py
@@ -324,7 +324,8 @@ class Alert(BaseEncodable):
     @notifications.setter
     def notifications(self, value):
         if not isinstance(value, list): raise ValueError("value should be of list type, but is: %s" % type(value))
-        # TODO Check for item type also
+        for item in value:
+            if not isinstance(item, Notification): raise ValueError("array member should be of Notification type, but is: %s" % type(item))
         self._notifications = value
 
 


### PR DESCRIPTION
The current code silently discards notifications when adding more than one using syntax like so:
```
        alertobj = Alert(
            alert_name,
            alert_expr,
            alert['alert']['cron_entry'],
            trigger=trigger,
            enabled=True,
            **notifications=notifications,**
            missingDataNotificationEnabled=True,
        )
```