### PR TITLE
Flexible arguments to ag-status-indicator

### DIFF
--- a/argusclient/dashboardtags.py
+++ b/argusclient/dashboardtags.py
@@ -141,6 +141,6 @@ def AREA_CHART(*args, **kwargs):
     return _CHART(type='stackarea', *args, **kwargs)
 
 
-def STATUS_INDICATOR(name, hi, lo):
-    """ Generates an `ag-status-indicator` tag. """
-    return _STATUS_INDICATOR(name=name, hi=hi, lo=lo)
+def STATUS_INDICATOR(*args, **kwargs):
+    """Generates an `ag-status-indicator` tag with the passed in `name`,`hi`,`low` and METRIC attributes"""
+    return _STATUS_INDICATOR(*args, **kwargs)


### PR DESCRIPTION
Think having flexible arguments to the ```STATUS_INDICATOR```  is probably helpful.
Besides, it makes it uniform like other functions.

@hdara-sfdc  thoughts?