### PR TITLE
Adding new exception:ArgusObjectNotFoundException

### DIFF
--- a/argusclient/__init__.py
+++ b/argusclient/__init__.py
@@ -6,5 +6,5 @@
 # For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
 #
 
-from .client import ArgusServiceClient, ArgusException, ArgusAuthException, MetricQuery, AnnotationQuery
+from .client import ArgusServiceClient, ArgusException, ArgusAuthException, ArgusObjectNotFoundException, MetricQuery, AnnotationQuery
 from .model import Namespace, Metric, Annotation, Dashboard, Alert, Trigger, Notification, User, AddListResult

--- a/argusclient/client.py
+++ b/argusclient/client.py
@@ -34,6 +34,11 @@ class ArgusAuthException(ArgusException):
     """
     pass
 
+class ArgusObjectNotFoundException(ArgusException):
+    """
+    An exception type that is thrown for Argus object not found errors.
+    """
+    pass
 
 class BaseQuery(object):
     def __init__(self, baseExpr, *tailParams, **kwargs):
@@ -741,9 +746,9 @@ def check_success(resp, decCls):
             raise ArgusException(resp.text)
         return res
     elif resp.status_code == httplib.NOT_FOUND:
-        raise ArgusException("Object not found at endpoint: %s message: %s" % (resp.request.url, resp.text))
+        raise ArgusObjectNotFoundException("Object not found at endpoint: %s message: %s" % (resp.url, resp.text))
     elif resp.status_code == httplib.UNAUTHORIZED:
-        raise ArgusAuthException("Failed to authenticate at endpoint: %s message: %s" % (resp.request.url, resp.text))
+        raise ArgusAuthException("Failed to authenticate at endpoint: %s message: %s" % (resp.url, resp.text))
     else:
         # TODO handle this differently, as this is typically a more severe exception (see W-2830904)
         raise ArgusException(resp.text)


### PR DESCRIPTION
1. Addresses issue: https://github.com/salesforce/python-argusclient/issues/8
2. Couldn't get unit test to run without adding /meta for tests related to ```get_user_alert```
3. typo

Output of unit test:

```
python -m unittest discover tests/
...................................................................................................................
----------------------------------------------------------------------
Ran 115 tests in 0.033s

OK
```