### PR TITLE
Syntax Error: Fix missing colon (:) plus some Python 3 fixes

### DIFF
--- a/argusclient/client.py
+++ b/argusclient/client.py
@@ -16,7 +16,10 @@ import json
 import os
 import logging
 import collections
-import httplib
+try:
+    import http.client as httplib  # Python 3
+except ImportError:
+    import httplib                 # Python 2
 from functools import wraps
 
 from .model import Namespace, Metric, Annotation, Dashboard, Alert, Trigger, Notification, JsonEncoder, JsonDecoder

--- a/argusclient/model.py
+++ b/argusclient/model.py
@@ -11,10 +11,10 @@ Module containing the classes that model the Argus base objects.
 
 import json
 
-try:               # Python 2
-    basestring
-except NameError:  # Python 3
-    basestring = string
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
 
 
 class BaseEncodable(object):

--- a/argusclient/model.py
+++ b/argusclient/model.py
@@ -11,6 +11,11 @@ Module containing the classes that model the Argus base objects.
 
 import json
 
+try:               # Python 2
+    basestring
+except NameError:  # Python 3
+    basestring = string
+
 
 class BaseEncodable(object):
 

--- a/examples/splunk_to_argus.py
+++ b/examples/splunk_to_argus.py
@@ -58,7 +58,7 @@ if not opts.pattern:
     parser.error("Please specify a Splunk pattern to search for")
 if not opts.argusws:
     parser.error("Need the URL to the Argus endpoint")
-if not opts.splunkapi
+if not opts.splunkapi:
     parser.error("Need the URL to the Splunk endpoint")
 
 logging.basicConfig()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,12 +5,17 @@
 # For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
 #
 
-import unittest, mock, json, os
+import unittest, json, os
 
 from argusclient import *
 from argusclient.client import JsonEncoder, JsonDecoder, check_success
 
 from test_data import *
+
+try:
+    import mock      # Python 2
+except ImportError:  # Python 3
+    from unittest import mock
 
 
 class MockRequest(object):


### PR DESCRIPTION
flake8 testing of https://github.com/salesforce/python-argusclient on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./argusclient/model.py:248:52: F821 undefined name 'basestring'
        assert qualifier and isinstance(qualifier, basestring), "A string qualifier is required for namespace"
                                                   ^
./examples/csv2argus.py:165:42: E999 IndentationError: unindent does not match any outer indentation level
            for metricName in metricNames:
                                         ^
./examples/splunk_to_argus.py:61:21: E999 SyntaxError: invalid syntax
if not opts.splunkapi
                    ^
2     E999 IndentationError: unindent does not match any outer indentation level
1     F821 undefined name 'basestring'
3
```