### PR TITLE
Endpoint for calling GET /alerts/allinfo in argus webservice

### DIFF
--- a/argusclient/client.py
+++ b/argusclient/client.py
@@ -493,6 +493,16 @@ class AlertsServiceClient(BaseUpdatableModelServiceClient):
             assert len(alerts) == 1, "Expected a single alert as a result, but got: %s" % [a.name for a in alerts]
             return alerts[0]
 
+    def get_alerts_allinfo(self, ownerName=None, alertname=None, shared=False, limit=None):
+        """
+        If ownerName is not passed in, the username used during login is used.
+        Calls the GET /alerts/allinfo endpoint.
+        Returns the list of alerts (including associated notifications and triggers) created by the user.
+
+        :return: the list of :class:`argusclient.model.Alert` objects, with all fields populated, including triggers and notifications
+        """
+        return self.argus._request("get", "alerts/allinfo", params=dict(ownername=ownerName, alertname=alertname, shared=shared, limit=limit))
+
 
 class AlertTriggersServiceClient(BaseUpdatableModelServiceClient):
     """

--- a/argusclient/model.py
+++ b/argusclient/model.py
@@ -391,7 +391,8 @@ class Notification(BaseEncodable):
 
     :param name: The name of the notification
     :type name: str
-    :param notifierName: The name of the notifier implementation. Must be one of :attr:`EMAIL`, :attr:`AUDIT`, :attr:`GOC`, :attr:`GUS`
+    :param notifierName: The name of the notifier implementation. Must be one of :attr:`EMAIL`, :attr:`AUDIT`, :attr:`GOC`,
+            :attr:`GUS`, :attr:`CALLBACK`, :attr:`PAGER_DUTY`, :attr:`REFOCUS_BOOLEAN`, :attr:`REFOCUS_VALUE`, :attr:`SLACK`
     :type notifierName: str
 
     **Optional parameters to the constructor:**

--- a/argusclient/model.py
+++ b/argusclient/model.py
@@ -419,9 +419,11 @@ class Notification(BaseEncodable):
     PAGER_DUTY = "com.salesforce.dva.argus.service.alert.notifier.PagerDutyNotifier"
     REFOCUS_BOOLEAN = "com.salesforce.dva.argus.service.alert.notifier.RefocusBooleanNotifier"
     REFOCUS_VALUE = "com.salesforce.dva.argus.service.alert.notifier.RefocusValueNotifier"
+    SLACK = "com.salesforce.dva.argus.service.alert.notifier.SlackNotifier"
 
     #: Set of all valid notifier implementation names.
-    VALID_NOTIFIERS = frozenset((EMAIL, AUDIT, GOC, GUS, CALLBACK, PAGER_DUTY, REFOCUS_BOOLEAN, REFOCUS_VALUE))
+    VALID_NOTIFIERS = frozenset((EMAIL, AUDIT, GOC, GUS, CALLBACK, PAGER_DUTY,
+                                 REFOCUS_BOOLEAN, REFOCUS_VALUE, SLACK))
 
     def __init__(self, name, notifierName, metricsToAnnotate=None, **kwargs):
         assert notifierName in Notification.VALID_NOTIFIERS, "notifierName is not valid: %s" % notifierName

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -114,6 +114,22 @@ addannotationresult_D = {
     "Success": "1 annotations"
 }
 
+alert_D = {
+    "id": testId,
+    "createdById": 101997,
+    "createdDate": 1459857033871,
+    "modifiedById": 101997,
+    "modifiedDate": 1459857033871,
+    "name": alertName,
+    "expression": "-1d:hdara:test:sum",
+    "cronEntry": "*/15 * * * *",
+    "enabled": False,
+    "missingDataNotificationEnabled": False,
+    "notificationsIds": [],
+    "triggersIds": [],
+    "ownerName": userName
+}
+
 trigger_D = {
     "id": testId,
     "createdById": 101997,
@@ -145,22 +161,6 @@ notification_D = {
     "cooldownExpiration": 0,
     "triggersIds": [],
     "alertId": 304255
-}
-
-alert_D = {
-    "id": testId,
-    "createdById": 101997,
-    "createdDate": 1459857033871,
-    "modifiedById": 101997,
-    "modifiedDate": 1459857033871,
-    "name": alertName,
-    "expression": "-1d:hdara:test:sum",
-    "cronEntry": "*/15 * * * *",
-    "enabled": False,
-    "missingDataNotificationEnabled": False,
-    "notificationsIds": [],
-    "triggersIds": [],
-    "ownerName": userName
 }
 
 alert_all_info_D = {

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -163,3 +163,20 @@ alert_D = {
     "ownerName": userName
 }
 
+alert_all_info_D = {
+    "id": testId,
+    "createdById": 101997,
+    "createdDate": 1459857033871,
+    "modifiedById": 101997,
+    "modifiedDate": 1459857033871,
+    "name": alertName,
+    "expression": "-1d:hdara:test:sum",
+    "cronEntry": "*/15 * * * *",
+    "enabled": False,
+    "missingDataNotificationEnabled": False,
+    "notificationsIds": [testId, testId, testId],
+    "triggersIds": [testId, testId],
+    "triggers": [trigger_D, trigger_D],
+    "notifications": [notification_D, notification_D, notification_D],
+    "ownerName": userName
+}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -163,20 +163,3 @@ alert_D = {
     "ownerName": userName
 }
 
-alert_all_info_D = {
-    "id": testId,
-    "createdById": 101997,
-    "createdDate": 1459857033871,
-    "modifiedById": 101997,
-    "modifiedDate": 1459857033871,
-    "name": alertName,
-    "expression": "-1d:hdara:test:sum",
-    "cronEntry": "*/15 * * * *",
-    "enabled": False,
-    "missingDataNotificationEnabled": False,
-    "notificationsIds": [testId, testId, testId],
-    "triggersIds": [testId, testId],
-    "triggers": [trigger_D, trigger_D],
-    "notifications": [notification_D, notification_D, notification_D],
-    "ownerName": userName
-}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -114,22 +114,6 @@ addannotationresult_D = {
     "Success": "1 annotations"
 }
 
-alert_D = {
-    "id": testId,
-    "createdById": 101997,
-    "createdDate": 1459857033871,
-    "modifiedById": 101997,
-    "modifiedDate": 1459857033871,
-    "name": alertName,
-    "expression": "-1d:hdara:test:sum",
-    "cronEntry": "*/15 * * * *",
-    "enabled": False,
-    "missingDataNotificationEnabled": False,
-    "notificationsIds": [],
-    "triggersIds": [],
-    "ownerName": userName
-}
-
 trigger_D = {
     "id": testId,
     "createdById": 101997,
@@ -161,4 +145,38 @@ notification_D = {
     "cooldownExpiration": 0,
     "triggersIds": [],
     "alertId": 304255
+}
+
+alert_D = {
+    "id": testId,
+    "createdById": 101997,
+    "createdDate": 1459857033871,
+    "modifiedById": 101997,
+    "modifiedDate": 1459857033871,
+    "name": alertName,
+    "expression": "-1d:hdara:test:sum",
+    "cronEntry": "*/15 * * * *",
+    "enabled": False,
+    "missingDataNotificationEnabled": False,
+    "notificationsIds": [],
+    "triggersIds": [],
+    "ownerName": userName
+}
+
+alert_all_info_D = {
+    "id": testId,
+    "createdById": 101997,
+    "createdDate": 1459857033871,
+    "modifiedById": 101997,
+    "modifiedDate": 1459857033871,
+    "name": alertName,
+    "expression": "-1d:hdara:test:sum",
+    "cronEntry": "*/15 * * * *",
+    "enabled": False,
+    "missingDataNotificationEnabled": False,
+    "notificationsIds": [testId, testId, testId],
+    "triggersIds": [testId, testId],
+    "triggers": [trigger_D, trigger_D],
+    "notifications": [notification_D, notification_D, notification_D],
+    "ownerName": userName
 }

--- a/tests/test_modelobjs.py
+++ b/tests/test_modelobjs.py
@@ -198,6 +198,21 @@ class TestEncoding(unittest.TestCase):
     def testEncNotification(self):
         self._testFor(notification_D, Notification)
 
+    def testDecAlert(self):
+        jsonStr = json.dumps(alert_all_info_D)
+        o = json.loads(jsonStr, cls=JsonDecoder)
+        self._assertType(o, Alert)
+
+        assert o.triggers
+        assert len(o.triggers) == 2
+        for trigger in o.triggers:
+            self._assertType(trigger, Trigger)
+
+        assert o.notifications
+        assert len(o.notifications) == 3
+        for notif in o.notifications:
+            self._assertType(notif, Notification)
+
     def testNonModel(self):
         D = dict(someRandomField="1", anotherRandomField="2")
         jsonStr = json.dumps(D)
@@ -221,9 +236,12 @@ class TestEncoding(unittest.TestCase):
                 self.assertEquals(c.from_dict(D), None, "Expected None for class: %s" % c)
         jsonStr = json.dumps(D)
         o = json.loads(jsonStr, cls=JsonDecoder)
-        self.assertTrue(isinstance(o, objClass), "Encoded obj of type: %s is not of expected type: %s" % (type(o), objClass))
+        self._assertType(o, objClass)
         self.assertEquals(json.loads(jsonStr), D)
 
+    def _assertType(self, obj, objClass):
+        self.assertTrue(isinstance(obj, objClass),
+                "Encoded obj of type: %s is not of expected type: %s" % (type(obj), objClass))
 
 class TestW_2816614(unittest.TestCase):
     def test_namespace_qualifier(self):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -457,6 +457,18 @@ class TestAlert(TestServiceBase):
         self.failUnlessRaises(AssertionError, lambda: self.argus.alerts.get_user_alert(testId, testId))
         self.assertIn((os.path.join(endpoint, "alerts/meta"),), tuple(mockGet.call_args))
 
+    @mock.patch('requests.Session.get', return_value=MockResponse(json.dumps([alert_all_info_D, alert_all_info_D]), 200))
+    def testGetAlertsAllInfo(self, mockGet):
+        res = self.argus.alerts.get_alerts_allinfo(userName)
+        if res:
+            for obj in res:
+                self.assertTrue(isinstance(obj, Alert))
+                self.assertIsNotNone(obj.triggers)
+                self.assertIsNotNone(obj.notifications)
+                self.assertEqual(len(obj.triggers), 2)
+                self.assertEqual(len(obj.notifications), 3)
+        self.assertIn((os.path.join(endpoint, "alerts/allinfo"),), tuple(mockGet.call_args))
+
 
 class TestAlertTrigger(TestServiceBase):
     @mock.patch('requests.Session.get', return_value=MockResponse(json.dumps(alert_D), 200))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -457,16 +457,12 @@ class TestAlert(TestServiceBase):
         self.failUnlessRaises(AssertionError, lambda: self.argus.alerts.get_user_alert(testId, testId))
         self.assertIn((os.path.join(endpoint, "alerts/meta"),), tuple(mockGet.call_args))
 
-    @mock.patch('requests.Session.get', return_value=MockResponse(json.dumps([alert_all_info_D, alert_all_info_D]), 200))
+    @mock.patch('requests.Session.get', return_value=MockResponse(json.dumps([alert_D, alert_D]), 200))
     def testGetAlertsAllInfo(self, mockGet):
         res = self.argus.alerts.get_alerts_allinfo(userName)
         if res:
             for obj in res:
                 self.assertTrue(isinstance(obj, Alert))
-                self.assertIsNotNone(obj.triggers)
-                self.assertIsNotNone(obj.notifications)
-                self.assertEqual(len(obj.triggers), 2)
-                self.assertEqual(len(obj.notifications), 3)
         self.assertIn((os.path.join(endpoint, "alerts/allinfo"),), tuple(mockGet.call_args))
 
 


### PR DESCRIPTION
The new GET /alerts/allinfo endpoint in argus webservice returns the owner's alerts as well as the triggers and notifications.

This PR implements a method to call that endpoint.

This method will be used in moncfg to get the owner's alerts, triggers, and notifications and create files for them.

The method was tested for hitting the real endpoint and getting the trigger and notification data, in 6617adb
(This file was removed in a later commit. It was added to just show the test)

Previous PR which is the same:https://github.com/salesforce/python-argusclient/pull/18
This has the history of comments