### PR TITLE
Fix issue where alert object triggers/notifications attribute was overwritten by the client for the respective attribute

### DIFF
--- a/argusclient/client.py
+++ b/argusclient/client.py
@@ -551,8 +551,8 @@ class AlertsServiceClient(BaseUpdatableModelServiceClient):
         super(AlertsServiceClient, self).__init__(Alert, argus, id_path="alerts/%s", get_all_req_opts=get_all_req_opts)
 
     def _fill(self, alert):
-        alert._triggers = AlertTriggersServiceClient(self.argus, alert)
-        alert._notifications = AlertNotificationsServiceClient(self.argus, alert)
+        alert._triggers_client = AlertTriggersServiceClient(self.argus, alert)
+        alert._notifications_client = AlertNotificationsServiceClient(self.argus, alert)
         return alert
 
     def add(self, alert):
@@ -566,9 +566,9 @@ class AlertsServiceClient(BaseUpdatableModelServiceClient):
         alertobj = self._fill(self.argus._request("post", "alerts", dataObj=alert))
         self._coll[alertobj.id] = alertobj
         if alert.trigger:
-            alertobj.trigger = alertobj.triggers.add(alert.trigger)
+            alertobj.trigger = alertobj.triggers_client.add(alert.trigger)
         if alert.notification:
-            alertobj.notification = alertobj.notifications.add(alert.notification)
+            alertobj.notification = alertobj.notifications_client.add(alert.notification)
         if alert.trigger and alert.notification:
             self.argus.alerts.add_notification_trigger(alertobj.id, alertobj.notification.id, alertobj.trigger.id)
             alertobj.notification.triggersIds = [alertobj.trigger.id]

--- a/argusclient/model.py
+++ b/argusclient/model.py
@@ -329,6 +329,8 @@ class Alert(BaseEncodable):
     def __init__(self, name, expression, cronEntry, **kwargs):
         self._triggers = None
         self._notifications = None
+        self._triggers_client = None
+        self._notifications_client = None
         super(Alert, self).__init__(name=name, expression=expression, cronEntry=cronEntry, **kwargs)
 
     @property
@@ -358,6 +360,10 @@ class Alert(BaseEncodable):
         self._triggers = value
 
     @property
+    def triggers_client(self):
+        return self._triggers_client
+
+    @property
     def notification(self):
         """ A convenience property to be used when :attr:`notifications` contains a single :class:`argusclient.model.Notification`. """
         return self._notifications and len(self._notifications) == 1 and self._notifications[0] or None
@@ -382,6 +388,10 @@ class Alert(BaseEncodable):
         # This is a special case allowed only while adding new alerts, so ensure that argus_id of self and the objects is None.
         # TODO Check for item type also
         self._notifications = value
+
+    @property
+    def notifications_client(self):
+        return self._notifications_client
 
 
 class Trigger(BaseEncodable):


### PR DESCRIPTION
The `_triggers` & `_notifications` attribute is reserved for the list of triggers and notifications respectively. But in the `_fill` method of the alert service client, these attributes are overwritten by the client object for those services instead of the list of objects to create. Which means that if an `Alert` object was created with triggers & notifications defined, those are not usable afterwards. 

This fix resolves the name conflict by putting the clients in their own attribute. 